### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,7 +8,7 @@
 
 Firebase	KEYWORD1
 FirebaseData	KEYWORD1
-StreamData  KEYWORD1
+StreamData	KEYWORD1
 QueryFilter	KEYWORD1
 QueueManager	KEYWORD1
 HTTPClientESP32Ex	KEYWORD1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords