### PR TITLE
fix: remove StreamData::stringData quote

### DIFF
--- a/src/FirebaseESP32.cpp
+++ b/src/FirebaseESP32.cpp
@@ -5886,7 +5886,7 @@ bool StreamData::boolData()
 String StreamData::stringData()
 {
   if (_dataType == FirebaseESP32::FirebaseDataType::STRING)
-    return _data.c_str();
+    return _data.substr(1, _data.length() - 2).c_str();
   else
     return std::string().c_str();
 }


### PR DESCRIPTION
Removed string double quotes in StreamData::stringData() 

same as following
FirebaseData::stringData()
https://github.com/mobizt/Firebase-ESP32/blob/6ba6e2cba765c7fe08d4aeca1b69d1ac73e49ffb/src/FirebaseESP32.cpp#L5660